### PR TITLE
Fix import statements and color values

### DIFF
--- a/Generate Swift Extension.sketchplugin
+++ b/Generate Swift Extension.sketchplugin
@@ -7,7 +7,7 @@ var swatchLayers = getSwatchLayers();
 var methodSignatures = [];
 var uicolorCodes = [];
 
-var prefix = [doc askForUserInput:"What is your category prefix?" initialValue:"skc_"];
+var prefix = [doc askForUserInput:"What is your category prefix?" initialValue:"SKC"];
 
 for (var i=0; i < [swatchLayers count]; i++)
 {
@@ -32,13 +32,13 @@ var swiftText = commentHeader + swiftPrefix;
 for (var i=0; i < methodSignatures.length; i++)
 {
 
-  swiftText += methodSignatures[i];
+  swiftText += "\t" + methodSignatures[i];
   swiftText += newLine;
-  swiftText += "{";
+  swiftText += "\t" + "{";
   swiftText += newLine;
-  swiftText += "\t" + uicolorCodes[i];
+  swiftText += "\t\t" + uicolorCodes[i];
   swiftText += newLine;
-  swiftText += "}";
+  swiftText += "\t" + "}";
   swiftText += newLine;
   swiftText += newLine;
 }

--- a/Generate UIColor Category.sketchplugin
+++ b/Generate UIColor Category.sketchplugin
@@ -7,7 +7,7 @@ var swatchLayers = getSwatchLayers();
 var methodSignatures = [];
 var uicolorCodes = [];
 
-var prefix = [doc askForUserInput:"What is your category prefix?" initialValue:"skc_"];
+var prefix = [doc askForUserInput:"What is your category prefix?" initialValue:"SKC"];
 
 for (var i=0; i < [swatchLayers count]; i++)
 {
@@ -45,7 +45,6 @@ for (var i=0; i < methodSignatures.length; i++)
 
   hText += methodSignatures[i] + ";";
   hText += newLine;
-  hText += newLine;
 }
 
 mText += end;
@@ -59,7 +58,7 @@ saveFile(hPath, hText);
 
 function generateMethodSignature(name, prefix)
 {
-    return "+(UIColor *) " + prefix + name;
+    return "+ (UIColor *)" + prefix + name;
 }
 
 function generateFillColor(layer)

--- a/Generate UIColor Category.sketchplugin
+++ b/Generate UIColor Category.sketchplugin
@@ -70,5 +70,5 @@ function generateFillColor(layer)
   var blue = fill.color().blue().toFixed(3).toString();
   var alpha = fill.color().alpha().toFixed(3).toString();
 
-  return "return [UIColor colorWithRed:" + red + "f green:" + green + "f blue:" + blue + "f alpha:" + alpha + "f];";
+  return "return [UIColor colorWithRed:" + red + " green:" + green + " blue:" + blue + " alpha:" + alpha + "];";
 }

--- a/swift-config.js
+++ b/swift-config.js
@@ -16,6 +16,7 @@ commentHeader += newLine;
 commentHeader += newLine;
 
 swiftPrefix  = "import Foundation";
+swiftPrefix += newLine;
 swiftPrefix += "import UIKit";
 swiftPrefix += newLine;
 swiftPrefix += newLine;


### PR DESCRIPTION
Hello Jim, here's a pull request that fixes two bugs:
   - UIColors values were set as double instead of float,
   - The two import statements in the Swift extension were concatenated without adding a new line or a semi-column